### PR TITLE
Bumps log4j and java-ordered-properties to their latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     maven {
-        url "http://repo.spring.io/plugins-release/"
+        url "https://repo.spring.io/plugins-release/"
     }
     maven {
         url "https://jitpack.io"
@@ -26,10 +26,10 @@ dependencies {
     compile 'com.github.CoreyD97:BurpExtenderUtilities:8b5b654ac4d07fb6fcc8f0ae3a9c34ce553d7ea6'
     compile 'net.portswigger.burp.extender:burp-extender-api:1.7.22'
     compile 'com.google.code.gson:gson:2.8.6'
-    compile 'org.apache.logging.log4j:log4j-core:2.12.1'
+    compile 'org.apache.logging.log4j:log4j-core:2.17.1'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.10'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile group: 'nu.studer', name: 'java-ordered-properties', version: '1.0.1'
+    compile group: 'nu.studer', name: 'java-ordered-properties', version: '1.0.4'
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.62'
     compile group: 'org.swinglabs', name: 'swingx', version: '1.6.1'
     testCompile files('/opt/BurpSuitePro/burpsuite_pro.jar')


### PR DESCRIPTION
The upgrade of java-ordered-properties is required due to 1.0.1 missing
from repositories. Also, new configurations of Maven central don't upgrade
http to https and make gradlew fail due to the http:// configuration.