### PR TITLE
Automatic build of tagged commits with GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,33 @@
+---
+
+variables:
+  JDK_VERSION: '8u322-b06'
+  JDK_HASH: '3d62362a78c9412766471b05253507a4cfc212daea5cdf122860173ce902400e'
+
+stages:
+  - build
+
+build:
+  only:
+    - tags
+  stage: build
+  image: debian:bullseye
+  script: |
+    set -eux
+    apt-get update
+    apt-get -y upgrade
+    apt-get -y install git wget
+    v=$(echo "${JDK_VERSION}" | tr -d '-')
+    wget "https://github.com/adoptium/temurin8-binaries/releases/download/jdk${JDK_VERSION}/OpenJDK8U-jdk_x64_linux_hotspot_${v}.tar.gz"
+    [ "X${JDK_HASH}" = X$(sha256sum OpenJDK* | awk '{print $1;}') ]
+    gzip -cd Open* | tar -f- -x
+    PATH="$(pwd)/jdk${JDK_VERSION}/bin:${PATH}"
+    export PATH
+    
+    # https://github.com/gradle/gradle/issues/3117
+    env -i PATH="${PATH}" ./gradlew build -x test
+    mv ./releases/* ..
+    cd -
+    rm -rf ./jdk* ./Open* ./CollaboratorPlusPlus
+  artifacts:
+    untracked: true

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     maven {
-        url "http://repo.spring.io/plugins-release/"
+        url "https://repo.spring.io/plugins-release/"
     }
     maven {
         url "https://jitpack.io"
@@ -26,10 +26,10 @@ dependencies {
     compile 'com.github.CoreyD97:BurpExtenderUtilities:8b5b654ac4d07fb6fcc8f0ae3a9c34ce553d7ea6'
     compile 'net.portswigger.burp.extender:burp-extender-api:1.7.22'
     compile 'com.google.code.gson:gson:2.8.6'
-    compile 'org.apache.logging.log4j:log4j-core:2.12.1'
+    compile 'org.apache.logging.log4j:log4j-core:2.17.1'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.10'
     compile group: 'commons-io', name: 'commons-io', version: '2.4'
-    compile group: 'nu.studer', name: 'java-ordered-properties', version: '1.0.1'
+    compile group: 'nu.studer', name: 'java-ordered-properties', version: '1.0.4'
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.62'
     compile group: 'org.swinglabs', name: 'swingx', version: '1.6.1'
     testCompile files('/opt/BurpSuitePro/burpsuite_pro.jar')


### PR DESCRIPTION
To make a release, simply update the build.gradle file, tag the version
and push it. The CI will automically pick up the tag, build the JAR
and publish it as an artifact.